### PR TITLE
[udpnet] show speed of receiving stream

### DIFF
--- a/src/udpnet.cpp
+++ b/src/udpnet.cpp
@@ -481,6 +481,28 @@ static void do_read_local_messages() {
 
             state.lastRecvTime = GetTimeMillis();
 
+            /* update bytes stat
+             * for speed calculations (mbps)
+             * example:
+             *  ./bitcoind -fecreaddevice=/tmp/async_rx -fecstat=60
+             */
+            if (gArgs.IsArgSet("-fecstat")) {
+                int avgInterval = atoi(gArgs.GetArg("-fecstat", ""));
+                if (avgInterval <= 0) // invalid argument specified
+                    break;
+                if (!state.lastAvgTime)
+                    state.lastAvgTime = GetTimeMillis();
+                state.rcvdBytes += sizeof(UDPMessage) - 1;
+                int64_t timeDelta = GetTimeMillis() - state.lastAvgTime;
+                if (timeDelta > 1000*avgInterval) {
+                    // print statistics
+                    LogPrintf("UDP[%d]: Average speed %.4f Mbit/sec\n",
+                            fd, (double)state.rcvdBytes*8*1000/(1024*1024*timeDelta));
+                    state.lastAvgTime = GetTimeMillis();
+                    state.rcvdBytes = 0;
+                }
+            }
+
             if ((msg.header.msg_type & UDP_MSG_TYPE_TYPE_MASK) == MSG_TYPE_BLOCK_HEADER || (msg.header.msg_type & UDP_MSG_TYPE_TYPE_MASK) == MSG_TYPE_BLOCK_CONTENTS) {
                 if (!HandleBlockMessage(msg, sizeof(UDPMessage) - 1, it->first, it->second)) {
                     send_and_disconnect(it);

--- a/src/udpnet.h
+++ b/src/udpnet.h
@@ -170,8 +170,12 @@ struct UDPConnectionState {
     double last_pings[10];
     unsigned int last_ping_location;
     std::map<uint64_t, ChunksAvailableSet> chunks_avail;
+    // for speed calculations (mbps)
+    int64_t rcvdBytes;
+    int64_t lastAvgTime;
 
-    UDPConnectionState() : connection({}), state(0), protocolVersion(0), lastSendTime(0), lastRecvTime(0), lastPingTime(0), last_ping_location(0)
+    UDPConnectionState() : connection({}), state(0), protocolVersion(0), lastSendTime(0), lastRecvTime(0), lastPingTime(0), last_ping_location(0),
+	    rcvdBytes(0), lastAvgTime(0)
         { for (size_t i = 0; i < sizeof(last_pings) / sizeof(double); i++) last_pings[i] = -1; }
 };
 #define PROTOCOL_VERSION_MIN(ver) (((ver) >> 16) & 0xffff)


### PR DESCRIPTION
Speed report appears in bitcon/debug.log.
Following example shows speed of incoming stream for 'Blockstream
Satellite' project:

2017-08-23 20:39:00 UDP[27]: Average speed 0.0822 Mbit/sec
2017-08-23 20:40:00 UDP[27]: Average speed 0.0823 Mbit/sec
2017-08-23 20:41:00 UDP[27]: Average speed 0.0816 Mbit/sec

To enable periodic speed report use '-fecstat=' argument and specify
period in seconds.
Example:
./bitcoind -fecreaddevice=/tmp/async_rx -fecstat=60

this command will receive stream from '/tmp/async_rx' and report speed
every 60 secs.

Signed-off-by: Abylay Ospan <aospan@netup.ru>